### PR TITLE
Fixing finding licenses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ xctools = "xctools_kamaalio:cli.cli"
 
 [project]
 name = "xctools_kamaalio"
-version = "0.4.0"
+version = "0.5.0"
 authors = [{ name = "Kamaal Farah", email = "kamaal.f1@gmail.com" }]
 description = "A package to help deal with Xcode projects."
 readme = "README.md"


### PR DESCRIPTION
## Pull Request Overview

This PR replaces the `--scheme` flag with `--project`, introduces functions to locate Xcode’s DerivedData and SourcePackages paths, and refactors license discovery to use `pathlib`.

- Change CLI flag from `--scheme` to `--project` and update argument parsing.
- Add `get_xcode_derived_data_base` and `find_derived_data_for_project` to resolve DerivedData.
- Rewrite `get_packages_licenses` to use `Path.iterdir` and read license files.